### PR TITLE
Add ability to claim account from standalone iOS app

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const STATIC_CACHE_NAME = 'village-people-static-cache-v1'
+const STATIC_CACHE_NAME = 'village-people-static-cache-v2'
 const STATIC_REQUESTS_TO_CACHE = [
   'index.html',
   'env',

--- a/src/js/main/account/Routes.js
+++ b/src/js/main/account/Routes.js
@@ -14,6 +14,7 @@ function Routes({ match: { path } }) {
   return (
     <Layout>
       <Switch>
+        <Route path={path} component={Views.Account} exact={true} />
         <Route path={path + '/claim-account'} component={Views.ClaimAccount} />
       </Switch>
     </Layout>

--- a/src/js/main/account/forms/ClaimAccountForm.js
+++ b/src/js/main/account/forms/ClaimAccountForm.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { SubmitButton } from '@launchpadlab/lp-components'
+
+function ClaimAccountForm({ onSubmit }) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        const formData = new FormData(e.target)
+        const params = Object.fromEntries(formData.entries())
+        return onSubmit(params)
+      }}
+    >
+      <div className="input-container">
+        <label htmlFor="token">Password</label>
+        <input id="token" name="token" required={true} autoComplete="off" />
+      </div>
+      <SubmitButton>Submit</SubmitButton>
+    </form>
+  )
+}
+
+export default ClaimAccountForm

--- a/src/js/main/account/views/Account.js
+++ b/src/js/main/account/views/Account.js
@@ -1,0 +1,28 @@
+import React from 'react'
+// import PropTypes from 'prop-types'
+import { ClaimAccountForm } from '../forms'
+import { useHistory } from 'react-router-dom'
+
+const propTypes = {}
+
+const defaultProps = {}
+
+function Account() {
+  const history = useHistory()
+  return (
+    <div className="claim-account">
+      <h2>Claim Your Account</h2>
+      <p>Please enter the password provided by your administrator.</p>
+      <ClaimAccountForm
+        onSubmit={({ token }) =>
+          history.push(`/account/claim-account?t=${token}`)
+        }
+      />
+    </div>
+  )
+}
+
+Account.propTypes = propTypes
+Account.defaultProps = defaultProps
+
+export default Account

--- a/src/js/main/account/views/ClaimAccount.js
+++ b/src/js/main/account/views/ClaimAccount.js
@@ -1,10 +1,6 @@
 import React, { useState, useEffect } from 'react'
 // import PropTypes from 'prop-types'
 import * as Types from 'types'
-// import { onMount, waitFor } from 'lp-hoc'
-// import { selectors } from '../reducer'
-// import * as actions from '../actions'
-// import * as apiActions from 'api-actions'
 import { Spinner } from '@launchpadlab/lp-components'
 import { useQuery } from 'utils'
 import { useHistory } from 'react-router-dom'
@@ -32,7 +28,7 @@ function ClaimAccount() {
       .then(() => history.push('/contacts'))
       .catch(() => {
         setError(
-          'Authentication failed. Please request a new url from your administrator'
+          'Authentication failed. Please reach out to your administrator'
         )
         setState(Types.LoadingStates.FAILURE)
       })

--- a/src/js/main/home/views/About.js
+++ b/src/js/main/home/views/About.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import * as LS from 'local-storage'
 import logo from 'images/logo.svg'
+import { isIos, isStandalone } from 'utils'
 
 const propTypes = {}
 
@@ -26,11 +27,18 @@ function About() {
           </>
         )}
         {!isAuthenticated && (
-          <p>
-            This is an application that provides management with a shared
-            address book for the staff in the Village. If you would like access,
-            please send a request to your administrator.
-          </p>
+          <>
+            <p>
+              This is an application that provides management with a shared
+              address book for the staff in the Village. If you would like
+              access, please send a request to your administrator.
+            </p>
+            {isStandalone() && isIos() && (
+              <Link to="/account" className="button-primary">
+                Claim Account
+              </Link>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/js/utils/isIos.js
+++ b/src/js/utils/isIos.js
@@ -1,0 +1,16 @@
+function isIos() {
+  return (
+    [
+      'iPad Simulator',
+      'iPhone Simulator',
+      'iPod Simulator',
+      'iPad',
+      'iPhone',
+      'iPod',
+    ].includes(navigator.platform) ||
+    // iPad on iOS 13 detection
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  )
+}
+
+export default isIos

--- a/src/js/utils/isStandalone.js
+++ b/src/js/utils/isStandalone.js
@@ -1,0 +1,5 @@
+function isStandalone() {
+  return 'standalone' in window.navigator && window.navigator.standalone
+}
+
+export default isStandalone

--- a/src/scss/pages/_main.scss
+++ b/src/scss/pages/_main.scss
@@ -95,7 +95,7 @@ Search
     background-repeat: no-repeat;
     background-size: 15px;
     @include rem(padding-left, 30px);
-    
+
   }
 }
 
@@ -181,5 +181,22 @@ Contacts
 
   .expandable-section-details{
     @include rem(padding, 0px 20px);
+  }
+}
+
+/*-----------------------
+Claim Account
+-----------------------*/
+.claim-account {
+  @include center;
+  @include rem(padding, 30px);
+  max-width: 600px;
+  text-align: center;
+
+  .input-container {
+    width: 60%;
+    display: block;
+    margin: 0 auto 1em auto;
+    text-align: left;
   }
 }


### PR DESCRIPTION
## Reviewer Details

### Items Addressed
- iOS 13+ (?) create an entirely separate container for the PWA that is installed via Add to Homepage. This means that app state (cache, service workers, local storage, indexedDB) are not shared between the two. Users need a way to manually enter the claim account token
